### PR TITLE
feat(comments): validation checkbox for validators [Assety s více úrovněmi vláken]

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -775,6 +775,12 @@ class BlenderKitUIProps(PropertyGroup):
     new_comment: StringProperty(
         name="New comment", description="Write your comment", default=""
     )
+    new_comment_is_validation: BoolProperty(
+        name="Validation comment",
+        description="Mark the new thread as part of the validation process "
+        "(visible to validators only)",
+        default=False,
+    )
     reply_id: IntProperty(
         name="Reply Id", description="Active comment id to reply to", default=0
     )

--- a/__init__.py
+++ b/__init__.py
@@ -779,7 +779,9 @@ class BlenderKitUIProps(PropertyGroup):
         name="Validation comment",
         description="Mark the new thread as part of the validation process "
         "(visible to validators only)",
-        default=False,
+        # Checked by default: the vast majority of validator-started threads
+        # are validation; a casual public comment is the exception.
+        default=True,
     )
     reply_id: IntProperty(
         name="Reply Id", description="Active comment id to reply to", default=0

--- a/client_lib.py
+++ b/client_lib.py
@@ -343,12 +343,17 @@ def get_comments(asset_id, api_key=""):
         )
 
 
-def create_comment(asset_id, comment_text, api_key, reply_to_id=0):
-    """Create a new comment."""
+def create_comment(asset_id, comment_text, api_key, reply_to_id=0, is_validation=False):
+    """Create a new comment.
+
+    is_validation marks a new thread as part of the validation process;
+    only honored by the server for validators.
+    """
     data = {
         "asset_id": asset_id,
         "comment_text": comment_text,
         "reply_to_id": reply_to_id,
+        "is_validation": is_validation,
     }
     data = ensure_minimal_data(data)
     with requests.Session() as session:

--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -12,7 +12,7 @@ import bpy
 # "blenderkit" is unreliable when several blenderkit* add-ons are enabled.
 if __package__:
     __package__ = __package__.rsplit(".tests", 1)[0]
-from . import global_vars, ui_panels
+from . import datas, global_vars, ui_panels
 
 
 class TestGetEnvironmentInfoString(unittest.TestCase):
@@ -240,3 +240,50 @@ class TestCommentsOrderPreference(unittest.TestCase):
 
         prefs_dict = utils.get_preferences_as_dict()
         self.assertIn("comments_order", prefs_dict)
+
+
+class TestPostCommentIsValidation(unittest.TestCase):
+    """The post-comment operator forwards is_validation only for validators
+    starting a new thread; replies inherit the thread type server-side."""
+
+    def setUp(self):
+        self.ui_props = bpy.context.window_manager.blenderkitUI
+        self._orig_profile = global_vars.BKIT_PROFILE
+        self._orig_comment = self.ui_props.new_comment
+        self._orig_is_validation = self.ui_props.new_comment_is_validation
+        global_vars.BKIT_PROFILE = datas.MineProfile(
+            id=1, firstName="Vera", lastName="Validator", canEditAllAssets=True
+        )
+        self.ui_props.new_comment = "needs fixes"
+        self.ui_props.new_comment_is_validation = True
+        self._orig_create_comment = ui_panels.client_lib.create_comment
+        self.calls = []
+        ui_panels.client_lib.create_comment = lambda *args: self.calls.append(args)
+
+    def tearDown(self):
+        ui_panels.client_lib.create_comment = self._orig_create_comment
+        global_vars.BKIT_PROFILE = self._orig_profile
+        self.ui_props.new_comment = self._orig_comment
+        self.ui_props.new_comment_is_validation = self._orig_is_validation
+
+    def test_validator_new_thread_sends_is_validation(self):
+        result = bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=0)
+        self.assertEqual(result, {"FINISHED"})
+        asset_id, text, _api_key, reply_to, is_validation = self.calls[0]
+        self.assertEqual(asset_id, "test-asset")
+        self.assertEqual(text, "needs fixes")
+        self.assertEqual(reply_to, 0)
+        self.assertTrue(is_validation)
+        # the draft is cleared and the checkbox returns to its checked default
+        self.assertEqual(self.ui_props.new_comment, "")
+        self.assertTrue(self.ui_props.new_comment_is_validation)
+
+    def test_reply_never_sends_is_validation(self):
+        bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=42)
+        self.assertFalse(self.calls[0][4])
+        self.assertEqual(self.calls[0][3], 42)
+
+    def test_non_validator_never_sends_is_validation(self):
+        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=False)
+        bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=0)
+        self.assertFalse(self.calls[0][4])

--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -14,7 +14,7 @@ import bpy
 # "blenderkit" is unreliable when several blenderkit* add-ons are enabled.
 if __package__:
     __package__ = __package__.rsplit(".tests", 1)[0]
-from . import datas, global_vars, ui_panels
+from . import global_vars, ui_panels
 
 
 class TestGetEnvironmentInfoString(unittest.TestCase):
@@ -250,12 +250,12 @@ class TestPostCommentIsValidation(unittest.TestCase):
 
     def setUp(self):
         self.ui_props = bpy.context.window_manager.blenderkitUI
-        self._orig_profile = global_vars.BKIT_PROFILE
         self._orig_comment = self.ui_props.new_comment
         self._orig_is_validation = self.ui_props.new_comment_is_validation
-        global_vars.BKIT_PROFILE = datas.MineProfile(
-            id=1, firstName="Vera", lastName="Validator", canEditAllAssets=True
+        self._validator_patch = patch.object(
+            ui_panels.utils, "profile_is_validator", return_value=True
         )
+        self._validator_patch.start()
         self.ui_props.new_comment = "needs fixes"
         self.ui_props.new_comment_is_validation = True
         self._orig_create_comment = ui_panels.client_lib.create_comment
@@ -264,7 +264,7 @@ class TestPostCommentIsValidation(unittest.TestCase):
 
     def tearDown(self):
         ui_panels.client_lib.create_comment = self._orig_create_comment
-        global_vars.BKIT_PROFILE = self._orig_profile
+        self._validator_patch.stop()
         self.ui_props.new_comment = self._orig_comment
         self.ui_props.new_comment_is_validation = self._orig_is_validation
 
@@ -286,8 +286,8 @@ class TestPostCommentIsValidation(unittest.TestCase):
         self.assertEqual(self.calls[0][3], 42)
 
     def test_non_validator_never_sends_is_validation(self):
-        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=False)
-        bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=0)
+        with patch.object(ui_panels.utils, "profile_is_validator", return_value=False):
+            bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=0)
         self.assertFalse(self.calls[0][4])
 
 
@@ -322,36 +322,36 @@ class _RecordingLayout:
 class TestDrawCommentResponseValidationCheckbox(unittest.TestCase):
     """The validation checkbox draws only for validators starting a thread."""
 
-    def setUp(self):
-        self._orig_profile = global_vars.BKIT_PROFILE
-
-    def tearDown(self):
-        global_vars.BKIT_PROFILE = self._orig_profile
-
-    def draw(self, comment_id):
+    def draw(self, comment_id, is_validator):
         layout = _RecordingLayout()
         fake_popup = SimpleNamespace(asset_data={"assetBaseId": "abc"})
         # nested "with": Blender 3.0 runs Python 3.9, which has no
         # parenthesized context managers yet
         with patch.object(ui_panels.utils, "user_logged_in", lambda: True):
             with patch.object(
-                ui_panels.icons,
-                "icon_collections",
-                {"main": {"post_comment": SimpleNamespace(icon_id=0)}},
+                ui_panels.utils, "profile_is_validator", return_value=is_validator
             ):
-                ui_panels.AssetPopupCard.draw_comment_response(
-                    fake_popup, bpy.context, layout, comment_id
-                )
+                with patch.object(
+                    ui_panels.icons,
+                    "icon_collections",
+                    {"main": {"post_comment": SimpleNamespace(icon_id=0)}},
+                ):
+                    ui_panels.AssetPopupCard.draw_comment_response(
+                        fake_popup, bpy.context, layout, comment_id
+                    )
         return layout.log
 
     def test_validator_sees_checkbox_on_new_thread(self):
-        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=True)
-        self.assertIn(("prop", "new_comment_is_validation"), self.draw(0))
+        self.assertIn(
+            ("prop", "new_comment_is_validation"), self.draw(0, is_validator=True)
+        )
 
     def test_no_checkbox_on_replies(self):
-        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=True)
-        self.assertNotIn(("prop", "new_comment_is_validation"), self.draw(42))
+        self.assertNotIn(
+            ("prop", "new_comment_is_validation"), self.draw(42, is_validator=True)
+        )
 
     def test_no_checkbox_for_non_validators(self):
-        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=False)
-        self.assertNotIn(("prop", "new_comment_is_validation"), self.draw(0))
+        self.assertNotIn(
+            ("prop", "new_comment_is_validation"), self.draw(0, is_validator=False)
+        )

--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -1,6 +1,8 @@
 import platform
 import sys
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 from urllib.parse import unquote
 
 import bpy
@@ -287,3 +289,69 @@ class TestPostCommentIsValidation(unittest.TestCase):
         global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=False)
         bpy.ops.wm.blenderkit_post_comment(asset_id="test-asset", comment_id=0)
         self.assertFalse(self.calls[0][4])
+
+
+class _RecordingLayout:
+    """Records prop/operator calls; mimics the tiny UILayout subset that
+    draw_comment_response uses."""
+
+    def __init__(self, log=None):
+        self.log = [] if log is None else log
+        self.active = True
+
+    def separator(self):
+        pass
+
+    def row(self, **kwargs):
+        return _RecordingLayout(self.log)
+
+    def split(self, **kwargs):
+        return _RecordingLayout(self.log)
+
+    def label(self, **kwargs):
+        pass
+
+    def prop(self, data, prop_name, **kwargs):
+        self.log.append(("prop", prop_name))
+
+    def operator(self, idname, **kwargs):
+        self.log.append(("operator", idname))
+        return SimpleNamespace()
+
+
+class TestDrawCommentResponseValidationCheckbox(unittest.TestCase):
+    """The validation checkbox draws only for validators starting a thread."""
+
+    def setUp(self):
+        self._orig_profile = global_vars.BKIT_PROFILE
+
+    def tearDown(self):
+        global_vars.BKIT_PROFILE = self._orig_profile
+
+    def draw(self, comment_id):
+        layout = _RecordingLayout()
+        fake_popup = SimpleNamespace(asset_data={"assetBaseId": "abc"})
+        # nested "with": Blender 3.0 runs Python 3.9, which has no
+        # parenthesized context managers yet
+        with patch.object(ui_panels.utils, "user_logged_in", lambda: True):
+            with patch.object(
+                ui_panels.icons,
+                "icon_collections",
+                {"main": {"post_comment": SimpleNamespace(icon_id=0)}},
+            ):
+                ui_panels.AssetPopupCard.draw_comment_response(
+                    fake_popup, bpy.context, layout, comment_id
+                )
+        return layout.log
+
+    def test_validator_sees_checkbox_on_new_thread(self):
+        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=True)
+        self.assertIn(("prop", "new_comment_is_validation"), self.draw(0))
+
+    def test_no_checkbox_on_replies(self):
+        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=True)
+        self.assertNotIn(("prop", "new_comment_is_validation"), self.draw(42))
+
+    def test_no_checkbox_for_non_validators(self):
+        global_vars.BKIT_PROFILE = datas.MineProfile(id=1, canEditAllAssets=False)
+        self.assertNotIn(("prop", "new_comment_is_validation"), self.draw(0))

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1295,10 +1295,20 @@ class PostComment(bpy.types.Operator):
         comments_utils.store_comments_local(self.asset_id, comments)
 
         # Send to server
+        is_validation = (
+            self.comment_id == 0
+            and ui_props.new_comment_is_validation
+            and global_vars.BKIT_PROFILE.canEditAllAssets
+        )
         client_lib.create_comment(
-            self.asset_id, ui_props.new_comment, api_key, self.comment_id
+            self.asset_id,
+            ui_props.new_comment,
+            api_key,
+            self.comment_id,
+            is_validation,
         )
         ui_props.new_comment = ""
+        ui_props.new_comment_is_validation = False
         return {"FINISHED"}
 
 
@@ -3863,6 +3873,11 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         )
         op.asset_id = self.asset_data["assetBaseId"]
         op.comment_id = comment_id
+
+        # Replies inherit the thread's type, so the choice only exists when
+        # starting a new thread.
+        if comment_id == 0 and global_vars.BKIT_PROFILE.canEditAllAssets:
+            layout.row().prop(ui_props, "new_comment_is_validation")
 
         layout.separator()
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1308,7 +1308,7 @@ class PostComment(bpy.types.Operator):
             is_validation,
         )
         ui_props.new_comment = ""
-        ui_props.new_comment_is_validation = False
+        ui_props.new_comment_is_validation = True
         return {"FINISHED"}
 
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1298,7 +1298,7 @@ class PostComment(bpy.types.Operator):
         is_validation = (
             self.comment_id == 0
             and ui_props.new_comment_is_validation
-            and global_vars.BKIT_PROFILE.canEditAllAssets
+            and utils.profile_is_validator()
         )
         client_lib.create_comment(
             self.asset_id,
@@ -3876,7 +3876,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
 
         # Replies inherit the thread's type, so the choice only exists when
         # starting a new thread.
-        if comment_id == 0 and global_vars.BKIT_PROFILE.canEditAllAssets:
+        if comment_id == 0 and utils.profile_is_validator():
             layout.row().prop(ui_props, "new_comment_is_validation")
 
         layout.separator()


### PR DESCRIPTION
Add-on side of validation-thread marking (server: BlenderKit/BlenderKit-server#3516).

- Validators (profile `canEditAllAssets`) get a **Validation comment** checkbox when starting a new comment thread; hidden on replies, which inherit the thread's type server-side.
- `client_lib.create_comment` passes `is_validation` to the Client; the flag resets after posting.
- Needs the matching bk_client change to forward the field (typed structs drop it today) — companion PR in bk_client. Until both ship, the server's template fallback ('Validation status: …' by a validator) classifies threads, so current add-on releases keep working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
