### PR TITLE
fix: handle missing author data in BlenderKitAssetBarOperator

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -5102,6 +5102,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         history_step = search.get_active_history_step()
         sr = history_step.get("search_results", [])
         asset_data = sr[asset_index]
+        author = asset_data.get("author")
+        if author is None:
+            return True
         author_id = asset_data["author"]["id"]
         if author_id is None:
             return True


### PR DESCRIPTION
There is miniature delay between asset-bar populating and asset data fill.
This prevents issues on miss-click