### PR TITLE
feat(usage): report which Blendkit assets are still in the file at every save [User issue investigation]

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2580,6 +2580,19 @@ In this case you should also set path to your system CA bundle containing proxy'
         update=utils.save_prefs,
     )
 
+    send_usage_data: BoolProperty(
+        name="Send usage data to improve Blendkit",
+        description=(
+            "Report which Blendkit assets are in your file when you save or render "
+            "(asset ids and counts only, no file names or scene content). Helps rank "
+            "search results by what people actually use and, in the future, reward "
+            "creators for assets that get used. The choice is stored in Blendkit-Client "
+            "and shared by every Blendkit add-on on this machine"
+        ),
+        default=True,
+        update=utils.send_usage_data_updated,
+    )
+
     accepted_ms_store_warning: BoolProperty(
         name="Accepted Microsoft Store Blender warning",
         description=(
@@ -2734,6 +2747,7 @@ In this case you should also set path to your system CA bundle containing proxy'
         login_box.prop(self, "keep_preferences")
         community_row = login_box.row()
         community_row.prop(self, "experimental_features")
+        login_box.prop(self, "send_usage_data")
         community_row.operator("wm.blenderkit_join_discord", icon="URL")
 
         if utils.profile_is_validator():

--- a/client_lib.py
+++ b/client_lib.py
@@ -413,7 +413,7 @@ def mark_notification_read(notification_id):
 
 
 ### REPORTS
-USAGE_REPORT_URL_SUFFIX = "/api/v1/usage_report/"
+USAGE_REPORT_URL_SUFFIX = "/api/v1/scene_save_reports/"
 USAGE_REPORT_ERROR = "Could not send the save-time usage report"
 
 

--- a/client_lib.py
+++ b/client_lib.py
@@ -414,13 +414,11 @@ def mark_notification_read(notification_id):
 
 ### REPORTS
 def report_usages(data: dict) -> requests.Response:
-    """Send the save-time usage report (the assets still in the file) via Blendkit-Client.
+    """Send a presence report (the assets in the file at a save or render) via Blendkit-Client.
 
-    The Client's dedicated ``/report_usages`` route forwards the report to the
-    server with the standard headers in the background and, like telemetry,
-    creates no Task: the report is a background signal sent on every save and
-    must never surface to the UI. A Client older than the route answers 404,
-    which the caller only logs.
+    The Client's ``/report_usages`` route forwards it as a ``report_usages``
+    task and drops it when the user opted out of usage data. A Client older
+    than the route answers 404, which the caller only logs.
     """
     payload = ensure_minimal_data({"report": data})
     with requests.Session() as session:
@@ -430,6 +428,43 @@ def report_usages(data: dict) -> requests.Response:
             timeout=TIMEOUT,
             proxies=NO_PROXIES,
         )
+
+
+def set_usage_data_opt_out(opt_out: bool) -> requests.Response:
+    """Store the shared usage-data opt-out in Blendkit-Client, where every host reads it."""
+    with requests.Session() as session:
+        return session.post(
+            f"{get_base_url()}/settings/set",
+            json={"usage_data_opt_out": opt_out},
+            timeout=TIMEOUT,
+            proxies=NO_PROXIES,
+        )
+
+
+# True while handle_settings_task writes a preference, so the preference's
+# update callback does not push the same value back to the Client.
+applying_client_settings = False
+
+
+def handle_settings_task(task) -> None:
+    """Mirror the Client's shared settings into the add-on preferences.
+
+    The Client broadcasts its settings on every report; the opt-out may have
+    been changed from another host, so the preference follows the Client.
+    """
+    global applying_client_settings
+    shared = (task.result or {}).get("shared") or {}
+    if "usage_data_opt_out" not in shared:
+        return
+    preferences = bpy.context.preferences.addons[__package__].preferences
+    wanted = not shared["usage_data_opt_out"]
+    if preferences.send_usage_data == wanted:
+        return
+    applying_client_settings = True
+    try:
+        preferences.send_usage_data = wanted
+    finally:
+        applying_client_settings = False
 
 
 def report_event(event: str, data: Optional[dict] = None) -> None:

--- a/client_lib.py
+++ b/client_lib.py
@@ -413,27 +413,23 @@ def mark_notification_read(notification_id):
 
 
 ### REPORTS
-USAGE_REPORT_URL_SUFFIX = "/api/v1/scene_save_reports/"
-USAGE_REPORT_ERROR = "Could not send the save-time usage report"
-
-
 def report_usages(data: dict) -> requests.Response:
-    """Send a usage report (the save-time asset presence) to the server via Blendkit-Client.
+    """Send the save-time usage report (the assets still in the file) via Blendkit-Client.
 
-    Goes through the Client's generic non-blocking forwarder, which adds the
-    auth headers and posts in the background: the Client has no dedicated
-    route for usage reports (the old ``/report_usages`` was never ported to the
-    Go Client, so reports posted there got a 404 and vanished silently). The
-    result task is routed by ``timer.handle_task`` to ``download.handle_usage_report_task``,
-    which logs it instead of showing a popup.
+    The Client's dedicated ``/report_usages`` route forwards the report to the
+    server with the standard headers in the background and, like telemetry,
+    creates no Task: the report is a background signal sent on every save and
+    must never surface to the UI. A Client older than the route answers 404,
+    which the caller only logs.
     """
-    return nonblocking_request(
-        f"{global_vars.SERVER}{USAGE_REPORT_URL_SUFFIX}",
-        "POST",
-        {},
-        data,
-        {"success": "", "error": USAGE_REPORT_ERROR},
-    )
+    payload = ensure_minimal_data({"report": data})
+    with requests.Session() as session:
+        return session.post(
+            f"{get_base_url()}/report_usages",
+            json=payload,
+            timeout=TIMEOUT,
+            proxies=NO_PROXIES,
+        )
 
 
 def report_event(event: str, data: Optional[dict] = None) -> None:

--- a/client_lib.py
+++ b/client_lib.py
@@ -413,16 +413,26 @@ def mark_notification_read(notification_id):
 
 
 ### REPORTS
-def report_usages(data: dict):
-    """Report usages of assets in current scene via Blendkit-Client to the server."""
-    data = ensure_minimal_data(data)
-    with requests.Session() as session:
-        return session.post(
-            f"{get_base_url()}/report_usages",
-            json=data,
-            timeout=TIMEOUT,
-            proxies=NO_PROXIES,
-        )
+USAGE_REPORT_URL_SUFFIX = "/api/v1/usage_report/"
+USAGE_REPORT_ERROR = "Could not send the save-time usage report"
+
+
+def report_usages(data: dict) -> requests.Response:
+    """Send a usage report (the save-time asset presence) to the server via Blendkit-Client.
+
+    Goes through the Client's generic non-blocking forwarder, which adds the
+    auth headers and posts in the background: the Client has no dedicated
+    route for usage reports (the old ``/report_usages`` was never ported to the
+    Go Client, so reports posted there got a 404 and vanished silently). The
+    result task is kept out of the UI by ``utils.handle_nonblocking_request_task``.
+    """
+    return nonblocking_request(
+        f"{global_vars.SERVER}{USAGE_REPORT_URL_SUFFIX}",
+        "POST",
+        {},
+        data,
+        {"success": "", "error": USAGE_REPORT_ERROR},
+    )
 
 
 def report_event(event: str, data: Optional[dict] = None) -> None:

--- a/client_lib.py
+++ b/client_lib.py
@@ -424,7 +424,8 @@ def report_usages(data: dict) -> requests.Response:
     auth headers and posts in the background: the Client has no dedicated
     route for usage reports (the old ``/report_usages`` was never ported to the
     Go Client, so reports posted there got a 404 and vanished silently). The
-    result task is kept out of the UI by ``utils.handle_nonblocking_request_task``.
+    result task is routed by ``timer.handle_task`` to ``download.handle_usage_report_task``,
+    which logs it instead of showing a popup.
     """
     return nonblocking_request(
         f"{global_vars.SERVER}{USAGE_REPORT_URL_SUFFIX}",

--- a/datas.py
+++ b/datas.py
@@ -21,6 +21,7 @@ class Prefs:
     api_key_timeout: int
     experimental_features: bool
     keep_preferences: bool
+    send_usage_data: bool
     directory_behaviour: str
     global_dir: str
     project_subdir: str

--- a/download.py
+++ b/download.py
@@ -27,6 +27,8 @@ import shutil
 import time
 from typing import Any, Optional
 
+import requests
+
 from . import (
     append_link,
     client_lib,
@@ -451,16 +453,23 @@ def cleanup_temp_enabled_addons() -> None:
 
 @persistent
 def scene_save(context) -> None:
-    """Do cleanup of Blendkit props and send a message to the server about assets used."""
-    # TODO this can be optimized by merging these 2 functions, since both iterate over all objects.
+    """Clean up Blendkit props and report which assets are still in the file.
+
+    One "save" usage report per scene, every save, listing every Blendkit
+    asset present with its instance count. The server keeps it as per-scene
+    presence state (what was kept, what was removed, and when) for search
+    evaluation and, only after simulation, a possible redistribution weight.
+    Saving must never fail because of this, so a Client that is not running
+    is logged and ignored.
+    """
     if bpy.app.background:
         return
     check_unused()
-    report_data = (
-        get_asset_usages()
-    )  # TODO: FIX OR REMOVE THIS (now returns empty dict all the time) https://github.com/BlenderKit/blenderkit/issues/1013
-    if report_data != {}:
-        client_lib.report_usages(report_data)
+    for report in build_save_reports():
+        try:
+            client_lib.report_usages(report)
+        except requests.RequestException as e:
+            bk_logger.warning("Could not send the save-time usage report: %s", e)
 
 
 def refresh_addon_search_results_status() -> None:
@@ -512,89 +521,103 @@ def scene_load(context) -> None:
     check_missing()
 
 
-# TODO: FIX OR REMOVE THIS BROKEN FUNCTION - remove empty dict all the time
-# https://github.com/BlenderKit/blenderkit/issues/1013
-def get_asset_usages() -> dict[str, Any]:
-    """Report the usage of assets to the server."""
-    sid = utils.get_scene_id()
-    assets = {}
-    asset_obs = []
-    scene = bpy.context.scene
-    asset_usages = {}
+def _asset_base_id(datablock) -> Optional[str]:
+    """assetBaseId of a Blendkit asset datablock, else None."""
+    asset_data = datablock.get("asset_data")
+    if not asset_data:
+        return None
+    return asset_data.get("assetBaseId")
 
-    for ob in scene.collection.objects:
-        if ob.get("asset_data") != None:
-            asset_obs.append(ob)
 
-    for ob in asset_obs:
-        asset_data = ob["asset_data"]
-        abid = asset_data["assetBaseId"]
+def collect_present_assets(scene, file_wide: bool = False) -> dict[str, int]:
+    """Blendkit assets present in ``scene`` at save time: {assetBaseId: instance count}.
 
-        if assets.get(abid) is None:
-            asset_usages[abid] = {"count": 1}
-            assets[abid] = asset_data
-        else:
-            asset_usages[abid]["count"] += 1
+    Counts what the file actually uses: objects linked to the scene (models and
+    collection instances), materials in their slots (one per slot), the scene's
+    world (HDRs), and the scene itself when it is a scene asset. Brushes and
+    node groups are not owned by a scene, so they are attributed once, to the
+    scene flagged ``file_wide`` (the active one). Orphan datablocks - a
+    material nobody uses, a node group with no users - do not count: Blender
+    drops them on save and the user evidently did not keep them.
+    """
+    counts: dict[str, int] = {}
 
-    # brushes
-    for b in bpy.data.brushes:
-        if b.get("asset_data") != None:
-            abid = b["asset_data"]["assetBaseId"]
-            asset_usages[abid] = {"count": 1}
-            assets[abid] = b["asset_data"]
-    # materials
-    for ob in scene.collection.objects:
-        for ms in ob.material_slots:
-            m = ms.material
+    def add(datablock, instances: int = 1) -> None:
+        abid = _asset_base_id(datablock)
+        if abid:
+            counts[abid] = counts.get(abid, 0) + instances
 
-            if m is not None and m.get("asset_data") is not None:
-                abid = m["asset_data"]["assetBaseId"]
-                if assets.get(abid) is None:
-                    asset_usages[abid] = {"count": 1}
-                    assets[abid] = m["asset_data"]
-                else:
-                    asset_usages[abid]["count"] += 1
+    for ob in scene.objects:
+        add(ob)
+        if ob.instance_collection is not None:
+            add(ob.instance_collection)
+        for slot in ob.material_slots:
+            if slot.material is not None:
+                add(slot.material)
+    if scene.world is not None:
+        add(scene.world)
+    add(scene)
+    if file_wide:
+        for brush in bpy.data.brushes:
+            add(brush)
+        for nodegroup in bpy.data.node_groups:
+            if nodegroup.users > 0:
+                add(nodegroup)
+    return counts
 
-    assets_list = []
-    assets_reported = scene.get("assets reported", {})
 
-    new_assets_count = 0
-    for k in asset_usages.keys():
-        if k not in assets_reported.keys():
-            data = asset_usages[k]
-            list_item = {
-                "asset": k,
-                "usageCount": data["count"],
-                "proximitySet": data.get("proximity", []),
+# Unchanged presence is re-reported at most this often. Every consumer of the
+# reports reads state (kept at 24 h, removed at T, present at an order's cut-off),
+# not save frequency, so identical consecutive saves carry nothing; the heartbeat
+# keeps "still here" fresh enough for all of them while dropping most rows.
+SAVE_REPORT_HEARTBEAT_SECONDS = 3600
+
+# scene uuid -> (monotonic time of the last report, the counts it carried).
+# In-process on purpose: the first save of every Blender session always reports,
+# which is itself a useful signal (the file was opened and worked on again).
+_last_save_reports: dict[str, tuple[float, dict[str, int]]] = {}
+
+
+def _report_due(scene_id: str, counts: dict[str, int], now: float) -> bool:
+    last = _last_save_reports.get(scene_id)
+    if last is None:
+        return True
+    last_at, last_counts = last
+    return counts != last_counts or now - last_at >= SAVE_REPORT_HEARTBEAT_SECONDS
+
+
+def build_save_reports(now: Optional[float] = None) -> list[dict[str, Any]]:
+    """One usage report per scene whose Blendkit presence changed (or is due a heartbeat).
+
+    Scenes that never touched Blendkit (no uuid, no assets) are skipped; a
+    scene with a uuid is reported even when empty, because "nothing left" is
+    exactly the removal the server needs to see. A scene whose assets are the
+    same as at its last report within ``SAVE_REPORT_HEARTBEAT_SECONDS`` is
+    skipped.
+    """
+    if now is None:
+        now = time.monotonic()
+    reports = []
+    active = bpy.context.scene
+    for scene in bpy.data.scenes:
+        counts = collect_present_assets(scene, file_wide=scene == active)
+        if scene.get("uuid") is None and not counts:
+            continue
+        scene_id = utils.get_scene_id(scene)
+        if not _report_due(scene_id, counts, now):
+            continue
+        _last_save_reports[scene_id] = (now, counts)
+        reports.append(
+            {
+                "scene": scene_id,
+                "reportType": "save",
+                "assetusageSet": [
+                    {"asset": abid, "usageCount": instances, "proximitySet": []}
+                    for abid, instances in sorted(counts.items())
+                ],
             }
-            assets_list.append(list_item)
-            new_assets_count += 1
-        if k not in assets_reported.keys():
-            assets_reported[k] = True
-
-    scene["assets reported"] = assets_reported
-
-    if new_assets_count == 0:
-        bk_logger.debug("no new assets were added")
-        return {}
-    usage_report = {"scene": sid, "reportType": "save", "assetusageSet": assets_list}
-
-    au = scene.get("assets used", {})
-    ad = scene.get("assets deleted", {})
-
-    ak = assets.keys()
-    for k in au.keys():
-        if k not in ak:
-            ad[k] = au[k]
-        else:
-            if k in ad:
-                ad.pop(k)
-
-    # scene['assets used'] = {}
-    for k in ak:  # rewrite assets used.
-        scene["assets used"][k] = assets[k]
-
-    return usage_report
+        )
+    return reports
 
 
 def _sanitize_for_idprops(value: Any) -> Any:

--- a/download.py
+++ b/download.py
@@ -451,6 +451,18 @@ def cleanup_temp_enabled_addons() -> None:
         bk_logger.error("Error during temporary addon cleanup: %s", e)
 
 
+def handle_usage_report_task(task: client_tasks.Task) -> None:
+    """Result of a presence report: logged, never a popup."""
+    if task.status == "error":
+        bk_logger.warning("Usage report failed: %s", task.message)
+    elif task.status == "finished":
+        bk_logger.debug("Usage report sent")
+
+
+def usage_reports_enabled() -> bool:
+    return bool(bpy.context.preferences.addons[__package__].preferences.send_usage_data)
+
+
 @persistent
 def scene_save(context) -> None:
     """Clean up Blendkit props and report which assets are still in the file.
@@ -465,6 +477,8 @@ def scene_save(context) -> None:
     if bpy.app.background:
         return
     check_unused()
+    if not usage_reports_enabled():
+        return
     _send_presence_reports(build_save_reports())
 
 
@@ -476,7 +490,7 @@ def scene_render_complete(scene, *_args) -> None:
     save report it is a background signal: a Client that is not running is
     logged and ignored, and rendering can never fail because of it.
     """
-    if bpy.app.background:
+    if bpy.app.background or not usage_reports_enabled():
         return
     if not hasattr(scene, "objects"):
         scene = bpy.context.scene

--- a/download.py
+++ b/download.py
@@ -451,6 +451,27 @@ def cleanup_temp_enabled_addons() -> None:
         bk_logger.error("Error during temporary addon cleanup: %s", e)
 
 
+def is_usage_report_task(task: client_tasks.Task) -> bool:
+    """A Client non-blocking request result carrying the save-time usage report.
+
+    The Client's forwarder returns every request as ``wrappers/nonblocking_request``
+    (it has no route of its own for usage reports), so the report is told apart
+    by the URL it was sent to.
+    """
+    return str(task.data.get("url", "")).endswith(client_lib.USAGE_REPORT_URL_SUFFIX)
+
+
+def handle_usage_report_task(task: client_tasks.Task) -> None:
+    """Result of a save-time usage report: a background signal, logged, never a popup."""
+    if task.status == "error":
+        bk_logger.warning("Save-time usage report failed: %s", task.message)
+    elif task.status == "finished":
+        bk_logger.debug(
+            "Save-time usage report sent for scene %s",
+            task.data.get("json", {}).get("scene"),
+        )
+
+
 @persistent
 def scene_save(context) -> None:
     """Clean up Blendkit props and report which assets are still in the file.

--- a/download.py
+++ b/download.py
@@ -465,15 +465,39 @@ def scene_save(context) -> None:
     if bpy.app.background:
         return
     check_unused()
-    for report in build_save_reports():
+    _send_presence_reports(build_save_reports())
+
+
+@persistent
+def scene_render_complete(scene, *_args) -> None:
+    """Report the assets present in the scene a render job just finished for.
+
+    Runs on ``render_complete`` (once per render job, not per frame). Like the
+    save report it is a background signal: a Client that is not running is
+    logged and ignored, and rendering can never fail because of it.
+    """
+    if bpy.app.background:
+        return
+    if not hasattr(scene, "objects"):
+        scene = bpy.context.scene
+    report = build_render_report(scene)
+    if report is not None:
+        _send_presence_reports([report])
+
+
+def _send_presence_reports(reports: list[dict[str, Any]]) -> None:
+    for report in reports:
         try:
             response = client_lib.report_usages(report)
         except requests.RequestException as e:
-            bk_logger.warning("Could not send the save-time usage report: %s", e)
+            bk_logger.warning(
+                "Could not send the %s-time usage report: %s", report["event"], e
+            )
             continue
         if not response.ok:
             bk_logger.warning(
-                "Blendkit-Client refused the save-time usage report: %s %s",
+                "Blendkit-Client refused the %s-time usage report: %s %s",
+                report["event"],
                 response.status_code,
                 response.text,
             )
@@ -579,51 +603,65 @@ def collect_present_assets(scene, file_wide: bool = False) -> dict[str, int]:
 # keeps "still here" fresh enough for all of them while dropping most rows.
 SAVE_REPORT_HEARTBEAT_SECONDS = 3600
 
-# scene uuid -> (monotonic time of the last report, the counts it carried).
+# (event, scene uuid) -> (monotonic time of the last report, the counts it carried).
 # In-process on purpose: the first save of every Blender session always reports,
 # which is itself a useful signal (the file was opened and worked on again).
-_last_save_reports: dict[str, tuple[float, dict[str, int]]] = {}
+# Saves and renders are tracked apart: a render right after a save must still
+# report, because the render is the evidence the server cannot get otherwise.
+_last_save_reports: dict[tuple[str, str], tuple[float, dict[str, int]]] = {}
 
 
-def _report_due(scene_id: str, counts: dict[str, int], now: float) -> bool:
-    last = _last_save_reports.get(scene_id)
+def _report_due(event: str, scene_id: str, counts: dict[str, int], now: float) -> bool:
+    last = _last_save_reports.get((event, scene_id))
     if last is None:
         return True
     last_at, last_counts = last
     return counts != last_counts or now - last_at >= SAVE_REPORT_HEARTBEAT_SECONDS
 
 
-def build_save_reports(now: Optional[float] = None) -> list[dict[str, Any]]:
-    """One usage report per scene whose Blendkit presence changed (or is due a heartbeat).
+def _presence_report(event: str, scene, now: float) -> Optional[dict[str, Any]]:
+    """The presence report for one scene at ``event``, or None when nothing is due.
 
     Scenes that never touched Blendkit (no uuid, no assets) are skipped; a
     scene with a uuid is reported even when empty, because "nothing left" is
     exactly the removal the server needs to see. A scene whose assets are the
-    same as at its last report within ``SAVE_REPORT_HEARTBEAT_SECONDS`` is
-    skipped.
+    same as at its last report of this event within
+    ``SAVE_REPORT_HEARTBEAT_SECONDS`` is skipped.
+    """
+    counts = collect_present_assets(scene, file_wide=scene == bpy.context.scene)
+    if scene.get("uuid") is None and not counts:
+        return None
+    scene_id = utils.get_scene_id(scene)
+    if not _report_due(event, scene_id, counts, now):
+        return None
+    _last_save_reports[(event, scene_id)] = (now, counts)
+    return {
+        "scene": scene_id,
+        "event": event,
+        "assetusageSet": [
+            {"asset": abid, "usageCount": instances, "proximitySet": []}
+            for abid, instances in sorted(counts.items())
+        ],
+    }
+
+
+def build_save_reports(now: Optional[float] = None) -> list[dict[str, Any]]:
+    """One "save" presence report per scene whose Blendkit presence changed (or is due a heartbeat)."""
+    if now is None:
+        now = time.monotonic()
+    reports = (_presence_report("save", scene, now) for scene in bpy.data.scenes)
+    return [report for report in reports if report is not None]
+
+
+def build_render_report(scene, now: Optional[float] = None) -> Optional[dict[str, Any]]:
+    """The "render" presence report for the scene a render job just finished for.
+
+    A render is the strongest evidence that the assets in the scene were
+    used, and the only one for files that are rendered but never saved.
     """
     if now is None:
         now = time.monotonic()
-    reports = []
-    active = bpy.context.scene
-    for scene in bpy.data.scenes:
-        counts = collect_present_assets(scene, file_wide=scene == active)
-        if scene.get("uuid") is None and not counts:
-            continue
-        scene_id = utils.get_scene_id(scene)
-        if not _report_due(scene_id, counts, now):
-            continue
-        _last_save_reports[scene_id] = (now, counts)
-        reports.append(
-            {
-                "scene": scene_id,
-                "assetusageSet": [
-                    {"asset": abid, "usageCount": instances, "proximitySet": []}
-                    for abid, instances in sorted(counts.items())
-                ],
-            }
-        )
-    return reports
+    return _presence_report("render", scene, now)
 
 
 def _sanitize_for_idprops(value: Any) -> Any:
@@ -2637,6 +2675,7 @@ def register_download() -> None:
     bpy.utils.register_class(BlenderkitAddonChoiceOperator)
     bpy.app.handlers.load_post.append(scene_load)
     bpy.app.handlers.save_pre.append(scene_save)
+    bpy.app.handlers.render_complete.append(scene_render_complete)
     bpy.app.handlers.load_post.append(scene_load_post)
 
 
@@ -2646,6 +2685,7 @@ def unregister_download() -> None:
     bpy.utils.unregister_class(BlenderkitAddonChoiceOperator)
     bpy.app.handlers.load_post.remove(scene_load)
     bpy.app.handlers.save_pre.remove(scene_save)
+    bpy.app.handlers.render_complete.remove(scene_render_complete)
     bpy.app.handlers.load_post.remove(scene_load_post)
     # Clean up any remaining temporarily enabled addons
     cleanup_temp_enabled_addons()

--- a/download.py
+++ b/download.py
@@ -451,27 +451,6 @@ def cleanup_temp_enabled_addons() -> None:
         bk_logger.error("Error during temporary addon cleanup: %s", e)
 
 
-def is_usage_report_task(task: client_tasks.Task) -> bool:
-    """A Client non-blocking request result carrying the save-time usage report.
-
-    The Client's forwarder returns every request as ``wrappers/nonblocking_request``
-    (it has no route of its own for usage reports), so the report is told apart
-    by the URL it was sent to.
-    """
-    return str(task.data.get("url", "")).endswith(client_lib.USAGE_REPORT_URL_SUFFIX)
-
-
-def handle_usage_report_task(task: client_tasks.Task) -> None:
-    """Result of a save-time usage report: a background signal, logged, never a popup."""
-    if task.status == "error":
-        bk_logger.warning("Save-time usage report failed: %s", task.message)
-    elif task.status == "finished":
-        bk_logger.debug(
-            "Save-time usage report sent for scene %s",
-            task.data.get("json", {}).get("scene"),
-        )
-
-
 @persistent
 def scene_save(context) -> None:
     """Clean up Blendkit props and report which assets are still in the file.
@@ -488,9 +467,16 @@ def scene_save(context) -> None:
     check_unused()
     for report in build_save_reports():
         try:
-            client_lib.report_usages(report)
+            response = client_lib.report_usages(report)
         except requests.RequestException as e:
             bk_logger.warning("Could not send the save-time usage report: %s", e)
+            continue
+        if not response.ok:
+            bk_logger.warning(
+                "Blendkit-Client refused the save-time usage report: %s %s",
+                response.status_code,
+                response.text,
+            )
 
 
 def refresh_addon_search_results_status() -> None:

--- a/download.py
+++ b/download.py
@@ -631,7 +631,6 @@ def build_save_reports(now: Optional[float] = None) -> list[dict[str, Any]]:
         reports.append(
             {
                 "scene": scene_id,
-                "reportType": "save",
                 "assetusageSet": [
                     {"asset": abid, "usageCount": instances, "proximitySet": []}
                     for abid, instances in sorted(counts.items())

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -98,6 +98,9 @@ def load_preferences_from_JSON():
     user_preferences.experimental_features = prefs.get(
         "experimental_features", user_preferences.experimental_features
     )
+    user_preferences.send_usage_data = prefs.get(
+        "send_usage_data", user_preferences.send_usage_data
+    )
     user_preferences.keep_preferences = prefs.get(
         "keep_preferences", user_preferences.keep_preferences
     )

--- a/tests/test.py
+++ b/tests/test.py
@@ -79,7 +79,11 @@ runner = unittest.TextTestRunner(buffer=False)
 suite = unittest.TestSuite()
 testLoader = unittest.TestLoader()
 
-_test_modules = [
+# Modules that must run first, in this order (the client tests expect the state
+# earlier modules leave behind). Every other ``tests/test_*.py`` in the installed
+# package is loaded after them automatically - a new test file never needs to be
+# registered here, and can never be skipped silently.
+_ordered_first = [
     "test_init",
     "test_upload",
     "test_paths",
@@ -105,11 +109,24 @@ _test_modules = [
     "test_override_extension_draw",
     "test_datas",
 ]
+_tests_dir = os.path.dirname(importlib.import_module(f"{name_match}.tests").__file__)
+_all_modules = sorted(
+    f[:-3]
+    for f in os.listdir(_tests_dir)
+    if f.startswith("test_") and f.endswith(".py")
+)
+_missing = [m for m in _ordered_first if m not in _all_modules]
+if _missing:
+    print(f"FATAL: ordered test modules not found in {_tests_dir}: {_missing}")
+    sys.exit(1)
+_test_modules = _ordered_first + [m for m in _all_modules if m not in _ordered_first]
 
 for _modname in _test_modules:
     _module = importlib.import_module(f"{name_match}.tests.{_modname}")
     suite.addTests(testLoader.loadTestsFromModule(_module))
-print(f"- {len(suite._tests)} tests discovered and loaded\n")
+print(
+    f"- {len(suite._tests)} test suites from {len(_test_modules)} modules loaded: {_test_modules}\n"
+)
 
 print(f"----- Running tests --------------------------------------------------")
 result = runner.run(suite)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,6 +65,7 @@ class Test01Registration(unittest.TestCase):
             "api_key_refresh": user_preferences.api_key_refresh,
             "api_key_timeout": user_preferences.api_key_timeout,
             "experimental_features": user_preferences.experimental_features,
+            "send_usage_data": user_preferences.send_usage_data,
             "keep_preferences": user_preferences.keep_preferences,
             # FILE PATHS
             "directory_behaviour": user_preferences.directory_behaviour,

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -258,69 +258,27 @@ class SaveReportDedupeTests(unittest.TestCase):
 
 
 class ReportUsagesTransportTests(unittest.TestCase):
-    """The report goes through the Client's generic forwarder, silently."""
+    """The report goes to the Client's dedicated route, which creates no task."""
 
-    def test_report_usages_uses_the_nonblocking_forwarder_to_the_scene_save_reports_api(
-        self,
-    ):
+    def test_report_usages_posts_the_report_to_the_clients_report_usages_route(self):
         report = {"scene": "scene-a", "assetusageSet": []}
         with (
             mock.patch.object(
-                client_lib.global_vars, "SERVER", "https://devel.blendkit.com"
+                client_lib, "get_base_url", return_value="http://127.0.0.1:62485"
             ),
-            mock.patch.object(client_lib, "nonblocking_request") as forwarder,
+            mock.patch.object(
+                client_lib, "_read_api_key_threadsafe", return_value="token"
+            ),
+            mock.patch("requests.Session.post") as post,
         ):
             client_lib.report_usages(report)
-        forwarder.assert_called_once_with(
-            "https://devel.blendkit.com/api/v1/scene_save_reports/",
-            "POST",
-            {},
-            report,
-            {"success": "", "error": client_lib.USAGE_REPORT_ERROR},
-        )
-
-    def _task(self, status, url, message=""):
-        return client_tasks.Task(
-            data={"url": url, "json": {"scene": "scene-a"}},
-            app_id="app",
-            task_type="wrappers/nonblocking_request",
-            status=status,
-            message=message,
-        )
-
-    def test_usage_report_task_is_told_apart_by_its_url(self):
-        self.assertTrue(
-            download.is_usage_report_task(
-                self._task(
-                    "finished", "https://devel.blendkit.com/api/v1/scene_save_reports/"
-                )
-            )
-        )
-        self.assertFalse(
-            download.is_usage_report_task(
-                self._task("finished", "https://devel.blendkit.com/api/v1/assets/1/")
-            )
-        )
-        self.assertFalse(
-            download.is_usage_report_task(
-                client_tasks.Task(
-                    data={}, app_id="app", task_type="wrappers/nonblocking_request"
-                )
-            )
-        )
-
-    def test_usage_report_task_results_are_logged_not_shown(self):
-        url = "https://devel.blendkit.com/api/v1/scene_save_reports/"
-        with mock.patch.object(utils.reports, "add_report") as add_report:
-            with self.assertLogs(download.bk_logger, level="DEBUG") as logs:
-                download.handle_usage_report_task(self._task("finished", url))
-            self.assertIn("scene-a", logs.output[0])
-            with self.assertLogs(download.bk_logger, level="WARNING") as logs:
-                download.handle_usage_report_task(
-                    self._task("error", url, "401 Unauthorized")
-                )
-            self.assertIn("401 Unauthorized", logs.output[0])
-        add_report.assert_not_called()
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], "http://127.0.0.1:62485/report_usages")
+        self.assertEqual(kwargs["json"]["report"], report)
+        self.assertEqual(kwargs["json"]["api_key"], "token")
+        self.assertIn("addon_version", kwargs["json"])
+        self.assertIn("app_id", kwargs["json"])
 
 
 class SceneSaveHandlerTests(unittest.TestCase):
@@ -348,6 +306,20 @@ class SceneSaveHandlerTests(unittest.TestCase):
 
         self.assertEqual([c["scene"] for c in calls], ["scene-a"])
         self.assertIn("Could not send the save-time usage report", logs.output[0])
+
+    def test_a_client_without_the_route_is_only_logged(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        refused = mock.Mock(ok=False, status_code=404, text="404 page not found")
+        with (
+            mock.patch.object(download, "bpy", fake_bpy([scene], scene)),
+            mock.patch.object(download, "check_unused"),
+            mock.patch.object(
+                download.client_lib, "report_usages", return_value=refused
+            ),
+            self.assertLogs(download.bk_logger, level="WARNING") as logs,
+        ):
+            download.scene_save(None)
+        self.assertIn("404", logs.output[0])
 
     def test_background_mode_reports_nothing(self):
         scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -179,6 +179,7 @@ class BuildSaveReportsTests(unittest.TestCase):
             reports[0],
             {
                 "scene": "scene-a",
+                "event": "save",
                 "assetusageSet": [
                     # brushes are attributed to the active scene only
                     {"asset": "brush-rock", "usageCount": 1, "proximitySet": []},
@@ -255,6 +256,71 @@ class SaveReportDedupeTests(unittest.TestCase):
             second.objects.clear()
             reports = download.build_save_reports(now=1001.0)
             self.assertEqual([r["scene"] for r in reports], ["scene-b"])
+
+
+class RenderReportTests(unittest.TestCase):
+    """A finished render reports the rendered scene, tracked apart from saves."""
+
+    def setUp(self):
+        download._last_save_reports.clear()
+        self.addCleanup(download._last_save_reports.clear)
+
+    def test_render_reports_the_rendered_scene_only(self):
+        rendered = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        other = make_scene(objects=[make_object("mod-chair")], uuid="scene-b")
+        scenes = fake_bpy([rendered, other], rendered)
+        with (
+            mock.patch.object(download, "bpy", scenes),
+            mock.patch.object(utils, "bpy", scenes),
+        ):
+            report = download.build_render_report(rendered, now=1000.0)
+        self.assertEqual(
+            report,
+            {
+                "scene": "scene-a",
+                "event": "render",
+                "assetusageSet": [
+                    {"asset": "mod-lamp", "usageCount": 1, "proximitySet": []}
+                ],
+            },
+        )
+
+    def test_render_after_an_identical_save_still_reports(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        scenes = fake_bpy([scene], scene)
+        with (
+            mock.patch.object(download, "bpy", scenes),
+            mock.patch.object(utils, "bpy", scenes),
+        ):
+            self.assertEqual(len(download.build_save_reports(now=1000.0)), 1)
+            self.assertIsNotNone(download.build_render_report(scene, now=1001.0))
+            # the same render again within the hour is a repeat, not new evidence
+            self.assertIsNone(download.build_render_report(scene, now=1002.0))
+            # and it did not swallow the next changed save
+            scene.objects.clear()
+            self.assertEqual(len(download.build_save_reports(now=1003.0)), 1)
+
+    def test_render_handler_sends_one_report_and_skips_background(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        ok = mock.Mock(ok=True)
+        with (
+            mock.patch.object(download, "bpy", fake_bpy([scene], scene)),
+            mock.patch.object(utils, "bpy", fake_bpy([scene], scene)),
+            mock.patch.object(
+                download.client_lib, "report_usages", return_value=ok
+            ) as sent,
+        ):
+            download.scene_render_complete(scene)
+        sent.assert_called_once()
+        self.assertEqual(sent.call_args.args[0]["event"], "render")
+        with (
+            mock.patch.object(
+                download, "bpy", fake_bpy([scene], scene, background=True)
+            ),
+            mock.patch.object(download.client_lib, "report_usages") as sent,
+        ):
+            download.scene_render_complete(scene)
+        sent.assert_not_called()
 
 
 class ReportUsagesTransportTests(unittest.TestCase):

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -287,27 +287,39 @@ class ReportUsagesTransportTests(unittest.TestCase):
             message=message,
         )
 
+    def test_usage_report_task_is_told_apart_by_its_url(self):
+        self.assertTrue(
+            download.is_usage_report_task(
+                self._task(
+                    "finished", "https://devel.blendkit.com/api/v1/usage_report/"
+                )
+            )
+        )
+        self.assertFalse(
+            download.is_usage_report_task(
+                self._task("finished", "https://devel.blendkit.com/api/v1/assets/1/")
+            )
+        )
+        self.assertFalse(
+            download.is_usage_report_task(
+                client_tasks.Task(
+                    data={}, app_id="app", task_type="wrappers/nonblocking_request"
+                )
+            )
+        )
+
     def test_usage_report_task_results_are_logged_not_shown(self):
         url = "https://devel.blendkit.com/api/v1/usage_report/"
         with mock.patch.object(utils.reports, "add_report") as add_report:
-            with self.assertLogs(utils.bk_logger, level="DEBUG") as logs:
-                utils.handle_nonblocking_request_task(self._task("finished", url))
+            with self.assertLogs(download.bk_logger, level="DEBUG") as logs:
+                download.handle_usage_report_task(self._task("finished", url))
             self.assertIn("scene-a", logs.output[0])
-            with self.assertLogs(utils.bk_logger, level="WARNING") as logs:
-                utils.handle_nonblocking_request_task(
+            with self.assertLogs(download.bk_logger, level="WARNING") as logs:
+                download.handle_usage_report_task(
                     self._task("error", url, "401 Unauthorized")
                 )
             self.assertIn("401 Unauthorized", logs.output[0])
         add_report.assert_not_called()
-
-    def test_other_nonblocking_tasks_still_report_to_the_ui(self):
-        with mock.patch.object(utils.reports, "add_report") as add_report:
-            utils.handle_nonblocking_request_task(
-                self._task(
-                    "error", "https://devel.blendkit.com/api/v1/assets/1/", "boom"
-                )
-            )
-        add_report.assert_called_once_with("boom", type="ERROR")
 
 
 class SceneSaveHandlerTests(unittest.TestCase):

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -18,6 +18,8 @@
 """The save-time presence report: which Blendkit assets are still in the file."""
 
 import unittest
+
+import bpy
 from types import SimpleNamespace
 from unittest import mock
 
@@ -264,6 +266,11 @@ class RenderReportTests(unittest.TestCase):
     def setUp(self):
         download._last_save_reports.clear()
         self.addCleanup(download._last_save_reports.clear)
+        enabled = mock.patch.object(
+            download, "usage_reports_enabled", return_value=True
+        )
+        enabled.start()
+        self.addCleanup(enabled.stop)
 
     def test_render_reports_the_rendered_scene_only(self):
         rendered = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
@@ -323,6 +330,54 @@ class RenderReportTests(unittest.TestCase):
         sent.assert_not_called()
 
 
+class UsageDataSettingTests(unittest.TestCase):
+    """The opt-out lives in Blendkit-Client; the preference pushes to it and mirrors it."""
+
+    def _prefs(self):
+        return bpy.context.preferences.addons[utils.__package__].preferences
+
+    def setUp(self):
+        self.original = self._prefs().send_usage_data
+        push = mock.patch.object(client_lib, "set_usage_data_opt_out")
+        self.push = push.start()
+        self.addCleanup(push.stop)
+        save = mock.patch.object(utils, "save_prefs")
+        save.start()
+        self.addCleanup(save.stop)
+        self.addCleanup(
+            lambda: setattr(self._prefs(), "send_usage_data", self.original)
+        )
+
+    def test_settings_broadcast_mirrors_the_opt_out_into_the_preference(self):
+        task = client_tasks.Task(
+            data={}, app_id="app", task_type="settings", status="finished"
+        )
+        task.result = {"shared": {"server": "https://x", "usage_data_opt_out": True}}
+        client_lib.handle_settings_task(task)
+        self.assertFalse(self._prefs().send_usage_data)
+        task.result = {"shared": {"server": "https://x", "usage_data_opt_out": False}}
+        client_lib.handle_settings_task(task)
+        self.assertTrue(self._prefs().send_usage_data)
+        # mirroring must not echo the value back to the Client
+        self.push.assert_not_called()
+        # an older Client without the setting changes nothing
+        task.result = {"shared": {"server": "https://x"}}
+        self._prefs().send_usage_data = False
+        client_lib.handle_settings_task(task)
+        self.assertFalse(self._prefs().send_usage_data)
+
+    def test_changing_the_preference_pushes_the_opt_out_to_the_client(self):
+        self._prefs().send_usage_data = True
+        self.push.reset_mock()
+        self._prefs().send_usage_data = False
+        self.push.assert_called_once_with(True)
+
+    def test_a_missing_client_does_not_break_the_preference(self):
+        self.push.side_effect = requests.ConnectionError("down")
+        with self.assertLogs(utils.bk_logger, level="WARNING"):
+            self._prefs().send_usage_data = not self._prefs().send_usage_data
+
+
 class ReportUsagesTransportTests(unittest.TestCase):
     """The report goes to the Client's dedicated route, which creates no task."""
 
@@ -351,6 +406,38 @@ class SceneSaveHandlerTests(unittest.TestCase):
     def setUp(self):
         download._last_save_reports.clear()
         self.addCleanup(download._last_save_reports.clear)
+        enabled = mock.patch.object(
+            download, "usage_reports_enabled", return_value=True
+        )
+        enabled.start()
+        self.addCleanup(enabled.stop)
+
+    def test_opted_out_saves_report_nothing(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        with (
+            mock.patch.object(download, "usage_reports_enabled", return_value=False),
+            mock.patch.object(download, "bpy", fake_bpy([scene], scene)),
+            mock.patch.object(download, "check_unused"),
+            mock.patch.object(download.client_lib, "report_usages") as report_usages,
+        ):
+            download.scene_save(None)
+            download.scene_render_complete(scene)
+        report_usages.assert_not_called()
+
+    def test_usage_report_task_results_are_logged_not_shown(self):
+        with mock.patch.object(utils.reports, "add_report") as add_report:
+            with self.assertLogs(download.bk_logger, level="WARNING") as logs:
+                download.handle_usage_report_task(
+                    client_tasks.Task(
+                        data={},
+                        app_id="app",
+                        task_type="report_usages",
+                        status="error",
+                        message="401 Unauthorized",
+                    )
+                )
+            self.assertIn("401 Unauthorized", logs.output[0])
+        add_report.assert_not_called()
 
     def test_sends_one_report_per_scene_and_survives_a_missing_client(self):
         scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -1,0 +1,352 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+"""The save-time presence report: which Blendkit assets are still in the file."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import requests
+
+if __package__:
+    __package__ = __package__.rsplit(".tests", 1)[0]
+
+from . import client_lib, client_tasks, download, utils
+
+
+class Block:
+    """A datablock stand-in: attributes plus the ID-property mapping Blender exposes."""
+
+    def __init__(self, asset_base_id=None, **attrs):
+        self._props = {}
+        if asset_base_id is not None:
+            self._props["asset_data"] = {"assetBaseId": asset_base_id, "name": "x"}
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+    def get(self, key, default=None):
+        return self._props.get(key, default)
+
+    def __getitem__(self, key):
+        return self._props[key]
+
+    def __setitem__(self, key, value):
+        self._props[key] = value
+
+
+def make_object(asset_base_id=None, materials=(), instance_collection=None):
+    return Block(
+        asset_base_id,
+        instance_collection=instance_collection,
+        material_slots=[SimpleNamespace(material=m) for m in materials],
+    )
+
+
+def make_scene(objects=(), world=None, asset_base_id=None, uuid=None):
+    scene = Block(asset_base_id, objects=list(objects), world=world)
+    if uuid is not None:
+        scene["uuid"] = uuid
+    return scene
+
+
+def fake_bpy(scenes, active, brushes=(), node_groups=(), background=False):
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            scenes=list(scenes), brushes=list(brushes), node_groups=list(node_groups)
+        ),
+        context=SimpleNamespace(scene=active),
+        app=SimpleNamespace(background=background),
+    )
+
+
+class CollectPresentAssetsTests(unittest.TestCase):
+    def test_counts_objects_collections_materials_world_and_scene(self):
+        glass = Block("mat-glass")
+        wood = Block("mat-wood")
+        chair_collection = Block("col-chair")
+        scene = make_scene(
+            objects=[
+                make_object("mod-lamp", materials=[glass, None]),
+                make_object("mod-lamp", materials=[glass, wood]),
+                make_object(instance_collection=chair_collection),
+                make_object(),  # plain Blender object, no asset_data
+            ],
+            world=Block("hdr-sky"),
+            asset_base_id="scene-studio",
+        )
+
+        counts = download.collect_present_assets(scene)
+
+        self.assertEqual(
+            counts,
+            {
+                "mod-lamp": 2,
+                "mat-glass": 2,
+                "mat-wood": 1,
+                "col-chair": 1,
+                "hdr-sky": 1,
+                "scene-studio": 1,
+            },
+        )
+
+    def test_file_wide_datablocks_only_for_the_flagged_scene_and_only_when_used(self):
+        scene = make_scene()
+        brushes = [Block("brush-rock"), Block()]
+        node_groups = [Block("ng-scatter", users=2), Block("ng-orphan", users=0)]
+
+        with mock.patch.object(
+            download, "bpy", fake_bpy([scene], scene, brushes, node_groups)
+        ):
+            self.assertEqual(
+                download.collect_present_assets(scene, file_wide=True),
+                {"brush-rock": 1, "ng-scatter": 1},
+            )
+            self.assertEqual(
+                download.collect_present_assets(scene, file_wide=False), {}
+            )
+
+    def test_scene_without_world_or_assets_is_empty(self):
+        self.assertEqual(download.collect_present_assets(make_scene()), {})
+
+
+class SceneIdTests(unittest.TestCase):
+    """A scene created from another one inherits its uuid; the report must not merge them."""
+
+    def test_second_scene_with_a_copied_uuid_gets_its_own(self):
+        first = make_scene(uuid="shared")
+        copy = make_scene(uuid="shared")
+        with mock.patch.object(utils, "bpy", fake_bpy([first, copy], first)):
+            self.assertEqual(utils.get_scene_id(first), "shared")
+            fresh = utils.get_scene_id(copy)
+            self.assertNotEqual(fresh, "shared")
+            self.assertEqual(copy["uuid"], fresh)
+            # stable on the next call, and the first scene is untouched
+            self.assertEqual(utils.get_scene_id(copy), fresh)
+            self.assertEqual(utils.get_scene_id(first), "shared")
+
+    def test_missing_uuid_is_generated_and_the_active_scene_is_the_default(self):
+        scene = make_scene()
+        with mock.patch.object(utils, "bpy", fake_bpy([scene], scene)):
+            generated = utils.get_scene_id()
+            self.assertEqual(scene["uuid"], generated)
+            self.assertEqual(utils.get_scene_id(scene), generated)
+
+
+class BuildSaveReportsTests(unittest.TestCase):
+    def setUp(self):
+        download._last_save_reports.clear()
+        self.addCleanup(download._last_save_reports.clear)
+
+    def test_reports_every_scene_that_touched_blendkit_and_skips_the_rest(self):
+        studio = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        emptied = make_scene(uuid="scene-b")  # had downloads, everything deleted since
+        untouched = make_scene()
+        appended = make_scene(
+            objects=[make_object("mod-chair")]
+        )  # assets, but no uuid yet
+        brushes = [Block("brush-rock")]
+
+        scenes = fake_bpy([studio, emptied, untouched, appended], studio, brushes)
+        with (
+            mock.patch.object(download, "bpy", scenes),
+            mock.patch.object(utils, "bpy", scenes),
+        ):
+            reports = download.build_save_reports()
+
+        self.assertEqual([r["scene"] for r in reports[:2]], ["scene-a", "scene-b"])
+        self.assertEqual(len(reports), 3)
+
+        self.assertTrue(
+            appended["uuid"], "a scene holding assets gets a uuid so it can be reported"
+        )
+        self.assertEqual(reports[2]["scene"], appended["uuid"])
+        self.assertEqual(
+            reports[0],
+            {
+                "scene": "scene-a",
+                "reportType": "save",
+                "assetusageSet": [
+                    # brushes are attributed to the active scene only
+                    {"asset": "brush-rock", "usageCount": 1, "proximitySet": []},
+                    {"asset": "mod-lamp", "usageCount": 1, "proximitySet": []},
+                ],
+            },
+        )
+        # an emptied scene is reported with nothing in it: that is the removal signal
+        self.assertEqual(reports[1]["assetusageSet"], [])
+
+    def test_scenes_sharing_a_copied_uuid_are_reported_separately(self):
+        first = make_scene(objects=[make_object("mod-lamp")], uuid="shared")
+        copy = make_scene(objects=[make_object("mod-chair")], uuid="shared")
+        with (
+            mock.patch.object(download, "bpy", fake_bpy([first, copy], first)),
+            mock.patch.object(utils, "bpy", fake_bpy([first, copy], first)),
+        ):
+            reports = download.build_save_reports()
+        self.assertEqual(reports[0]["scene"], "shared")
+        self.assertNotEqual(reports[1]["scene"], "shared")
+        self.assertEqual(reports[1]["scene"], copy["uuid"])
+        self.assertEqual(
+            [r["assetusageSet"][0]["asset"] for r in reports], ["mod-lamp", "mod-chair"]
+        )
+
+
+class SaveReportDedupeTests(unittest.TestCase):
+    """Unchanged presence is reported once per hour; every change is reported at once."""
+
+    def setUp(self):
+        download._last_save_reports.clear()
+        self.addCleanup(download._last_save_reports.clear)
+
+    def _scenes(self, *scenes):
+        return fake_bpy(list(scenes), scenes[0])
+
+    def test_identical_saves_within_the_hour_report_once(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        with (
+            mock.patch.object(download, "bpy", self._scenes(scene)),
+            mock.patch.object(utils, "bpy", self._scenes(scene)),
+        ):
+            self.assertEqual(len(download.build_save_reports(now=1000.0)), 1)
+            self.assertEqual(download.build_save_reports(now=1000.0 + 600), [])
+            # the heartbeat re-reports after an hour even though nothing changed
+            self.assertEqual(len(download.build_save_reports(now=1000.0 + 3600)), 1)
+            self.assertEqual(download.build_save_reports(now=1000.0 + 3700), [])
+
+    def test_any_change_reports_immediately(self):
+        lamp = make_object("mod-lamp")
+        scene = make_scene(objects=[lamp], uuid="scene-a")
+        with (
+            mock.patch.object(download, "bpy", self._scenes(scene)),
+            mock.patch.object(utils, "bpy", self._scenes(scene)),
+        ):
+            download.build_save_reports(now=1000.0)
+            scene.objects.append(make_object("mod-lamp"))  # a second instance
+            reports = download.build_save_reports(now=1001.0)
+            self.assertEqual(reports[0]["assetusageSet"][0]["usageCount"], 2)
+            scene.objects.clear()  # everything deleted: the removal is reported at once
+            self.assertEqual(
+                download.build_save_reports(now=1002.0)[0]["assetusageSet"], []
+            )
+            self.assertEqual(download.build_save_reports(now=1003.0), [])
+
+    def test_scenes_are_tracked_independently(self):
+        first = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        second = make_scene(objects=[make_object("mod-chair")], uuid="scene-b")
+        with (
+            mock.patch.object(download, "bpy", self._scenes(first, second)),
+            mock.patch.object(utils, "bpy", self._scenes(first, second)),
+        ):
+            self.assertEqual(len(download.build_save_reports(now=1000.0)), 2)
+            second.objects.clear()
+            reports = download.build_save_reports(now=1001.0)
+            self.assertEqual([r["scene"] for r in reports], ["scene-b"])
+
+
+class ReportUsagesTransportTests(unittest.TestCase):
+    """The report goes through the Client's generic forwarder, silently."""
+
+    def test_report_usages_uses_the_nonblocking_forwarder_to_the_usage_report_api(self):
+        report = {"scene": "scene-a", "reportType": "save", "assetusageSet": []}
+        with (
+            mock.patch.object(
+                client_lib.global_vars, "SERVER", "https://devel.blendkit.com"
+            ),
+            mock.patch.object(client_lib, "nonblocking_request") as forwarder,
+        ):
+            client_lib.report_usages(report)
+        forwarder.assert_called_once_with(
+            "https://devel.blendkit.com/api/v1/usage_report/",
+            "POST",
+            {},
+            report,
+            {"success": "", "error": client_lib.USAGE_REPORT_ERROR},
+        )
+
+    def _task(self, status, url, message=""):
+        return client_tasks.Task(
+            data={"url": url, "json": {"scene": "scene-a"}},
+            app_id="app",
+            task_type="wrappers/nonblocking_request",
+            status=status,
+            message=message,
+        )
+
+    def test_usage_report_task_results_are_logged_not_shown(self):
+        url = "https://devel.blendkit.com/api/v1/usage_report/"
+        with mock.patch.object(utils.reports, "add_report") as add_report:
+            with self.assertLogs(utils.bk_logger, level="DEBUG") as logs:
+                utils.handle_nonblocking_request_task(self._task("finished", url))
+            self.assertIn("scene-a", logs.output[0])
+            with self.assertLogs(utils.bk_logger, level="WARNING") as logs:
+                utils.handle_nonblocking_request_task(
+                    self._task("error", url, "401 Unauthorized")
+                )
+            self.assertIn("401 Unauthorized", logs.output[0])
+        add_report.assert_not_called()
+
+    def test_other_nonblocking_tasks_still_report_to_the_ui(self):
+        with mock.patch.object(utils.reports, "add_report") as add_report:
+            utils.handle_nonblocking_request_task(
+                self._task(
+                    "error", "https://devel.blendkit.com/api/v1/assets/1/", "boom"
+                )
+            )
+        add_report.assert_called_once_with("boom", type="ERROR")
+
+
+class SceneSaveHandlerTests(unittest.TestCase):
+    def setUp(self):
+        download._last_save_reports.clear()
+        self.addCleanup(download._last_save_reports.clear)
+
+    def test_sends_one_report_per_scene_and_survives_a_missing_client(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        calls = []
+
+        def report_usages(data):
+            calls.append(data)
+            raise requests.ConnectionError("Client not running")
+
+        with (
+            mock.patch.object(download, "bpy", fake_bpy([scene], scene)),
+            mock.patch.object(download, "check_unused"),
+            mock.patch.object(
+                download.client_lib, "report_usages", side_effect=report_usages
+            ),
+            self.assertLogs(download.bk_logger, level="WARNING") as logs,
+        ):
+            download.scene_save(None)
+
+        self.assertEqual([c["scene"] for c in calls], ["scene-a"])
+        self.assertIn("Could not send the save-time usage report", logs.output[0])
+
+    def test_background_mode_reports_nothing(self):
+        scene = make_scene(objects=[make_object("mod-lamp")], uuid="scene-a")
+        with (
+            mock.patch.object(
+                download, "bpy", fake_bpy([scene], scene, background=True)
+            ),
+            mock.patch.object(download.client_lib, "report_usages") as report_usages,
+        ):
+            download.scene_save(None)
+        report_usages.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_presence.py
+++ b/tests/test_save_presence.py
@@ -179,7 +179,6 @@ class BuildSaveReportsTests(unittest.TestCase):
             reports[0],
             {
                 "scene": "scene-a",
-                "reportType": "save",
                 "assetusageSet": [
                     # brushes are attributed to the active scene only
                     {"asset": "brush-rock", "usageCount": 1, "proximitySet": []},
@@ -261,8 +260,10 @@ class SaveReportDedupeTests(unittest.TestCase):
 class ReportUsagesTransportTests(unittest.TestCase):
     """The report goes through the Client's generic forwarder, silently."""
 
-    def test_report_usages_uses_the_nonblocking_forwarder_to_the_usage_report_api(self):
-        report = {"scene": "scene-a", "reportType": "save", "assetusageSet": []}
+    def test_report_usages_uses_the_nonblocking_forwarder_to_the_scene_save_reports_api(
+        self,
+    ):
+        report = {"scene": "scene-a", "assetusageSet": []}
         with (
             mock.patch.object(
                 client_lib.global_vars, "SERVER", "https://devel.blendkit.com"
@@ -271,7 +272,7 @@ class ReportUsagesTransportTests(unittest.TestCase):
         ):
             client_lib.report_usages(report)
         forwarder.assert_called_once_with(
-            "https://devel.blendkit.com/api/v1/usage_report/",
+            "https://devel.blendkit.com/api/v1/scene_save_reports/",
             "POST",
             {},
             report,
@@ -291,7 +292,7 @@ class ReportUsagesTransportTests(unittest.TestCase):
         self.assertTrue(
             download.is_usage_report_task(
                 self._task(
-                    "finished", "https://devel.blendkit.com/api/v1/usage_report/"
+                    "finished", "https://devel.blendkit.com/api/v1/scene_save_reports/"
                 )
             )
         )
@@ -309,7 +310,7 @@ class ReportUsagesTransportTests(unittest.TestCase):
         )
 
     def test_usage_report_task_results_are_logged_not_shown(self):
-        url = "https://devel.blendkit.com/api/v1/usage_report/"
+        url = "https://devel.blendkit.com/api/v1/scene_save_reports/"
         with mock.patch.object(utils.reports, "add_report") as add_report:
             with self.assertLogs(download.bk_logger, level="DEBUG") as logs:
                 download.handle_usage_report_task(self._task("finished", url))

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -317,6 +317,18 @@ class TestHandleTaskDispatch(unittest.TestCase):
             timer.handle_task(task)
         h.assert_called_once_with(task)
 
+    def test_settings_broadcast(self):
+        task = make_task(task_type="settings")
+        with mock.patch.object(timer.client_lib, "handle_settings_task") as h:
+            timer.handle_task(task)
+        h.assert_called_once_with(task)
+
+    def test_report_usages(self):
+        task = make_task(task_type="report_usages")
+        with mock.patch.object(timer.download, "handle_usage_report_task") as h:
+            timer.handle_task(task)
+        h.assert_called_once_with(task)
+
     def test_asset_upload(self):
         task = make_task(task_type="asset_upload")
         with mock.patch.object(timer.upload, "handle_asset_upload") as h:

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -317,21 +317,6 @@ class TestHandleTaskDispatch(unittest.TestCase):
             timer.handle_task(task)
         h.assert_called_once_with(task)
 
-    def test_nonblocking_usage_report_goes_to_its_own_handler(self):
-        task = make_task(
-            task_type="wrappers/nonblocking_request",
-            data={"url": "https://www.blendkit.com/api/v1/scene_save_reports/"},
-        )
-        with (
-            mock.patch.object(timer.download, "handle_usage_report_task") as usage,
-            mock.patch.object(
-                timer.utils, "handle_nonblocking_request_task"
-            ) as generic,
-        ):
-            timer.handle_task(task)
-        usage.assert_called_once_with(task)
-        generic.assert_not_called()
-
     def test_asset_upload(self):
         task = make_task(task_type="asset_upload")
         with mock.patch.object(timer.upload, "handle_asset_upload") as h:

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -320,7 +320,7 @@ class TestHandleTaskDispatch(unittest.TestCase):
     def test_nonblocking_usage_report_goes_to_its_own_handler(self):
         task = make_task(
             task_type="wrappers/nonblocking_request",
-            data={"url": "https://www.blendkit.com/api/v1/usage_report/"},
+            data={"url": "https://www.blendkit.com/api/v1/scene_save_reports/"},
         )
         with (
             mock.patch.object(timer.download, "handle_usage_report_task") as usage,

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -308,6 +308,30 @@ class TestHandleTaskDispatch(unittest.TestCase):
             timer.handle_task(task)
         h.assert_called_once_with(task)
 
+    def test_nonblocking_request(self):
+        task = make_task(
+            task_type="wrappers/nonblocking_request",
+            data={"url": "https://www.blendkit.com/api/v1/assets/1/"},
+        )
+        with mock.patch.object(timer.utils, "handle_nonblocking_request_task") as h:
+            timer.handle_task(task)
+        h.assert_called_once_with(task)
+
+    def test_nonblocking_usage_report_goes_to_its_own_handler(self):
+        task = make_task(
+            task_type="wrappers/nonblocking_request",
+            data={"url": "https://www.blendkit.com/api/v1/usage_report/"},
+        )
+        with (
+            mock.patch.object(timer.download, "handle_usage_report_task") as usage,
+            mock.patch.object(
+                timer.utils, "handle_nonblocking_request_task"
+            ) as generic,
+        ):
+            timer.handle_task(task)
+        usage.assert_called_once_with(task)
+        generic.assert_not_called()
+
     def test_asset_upload(self):
         task = make_task(task_type="asset_upload")
         with mock.patch.object(timer.upload, "handle_asset_upload") as h:

--- a/timer.py
+++ b/timer.py
@@ -487,6 +487,10 @@ def handle_task(task: client_tasks.Task):
     # HANDLE CLIENT STATUS REPORT
     if task.task_type == "client_status":
         return client_lib.handle_client_status_task(task)
+    if task.task_type == "settings":
+        return client_lib.handle_settings_task(task)
+    if task.task_type == "report_usages":
+        return download.handle_usage_report_task(task)
 
     # HANDLE DISCLAIMER
     if task.task_type == "disclaimer":

--- a/timer.py
+++ b/timer.py
@@ -536,8 +536,6 @@ def handle_task(task: client_tasks.Task):
 
     # HANDLE NONBLOCKING_REQUEST
     if task.task_type == "wrappers/nonblocking_request":
-        if download.is_usage_report_task(task):
-            return download.handle_usage_report_task(task)
         return utils.handle_nonblocking_request_task(task)
 
     # BKCLIENTJS - Download from web

--- a/timer.py
+++ b/timer.py
@@ -536,6 +536,8 @@ def handle_task(task: client_tasks.Task):
 
     # HANDLE NONBLOCKING_REQUEST
     if task.task_type == "wrappers/nonblocking_request":
+        if download.is_usage_report_task(task):
+            return download.handle_usage_report_task(task)
         return utils.handle_nonblocking_request_task(task)
 
     # BKCLIENTJS - Download from web

--- a/utils.py
+++ b/utils.py
@@ -724,10 +724,25 @@ def get_brush_icon_path(brush) -> str:
     return filepath
 
 
-def get_scene_id():
-    """gets scene id and possibly also generates a new one"""
-    bpy.context.scene["uuid"] = bpy.context.scene.get("uuid", str(uuid.uuid4()))
-    return bpy.context.scene["uuid"]
+def get_scene_id(scene=None):
+    """Return the scene's Blendkit uuid, generating and storing one when missing or shared.
+
+    Defaults to the active scene; pass a scene to address another one (the
+    save-time report covers every scene in the file). Blender copies custom
+    properties when a scene is created from another one ("New" included), so
+    a second scene starts out with the first one's uuid and the server would
+    merge the two into one history. The first scene in ``bpy.data.scenes``
+    keeps the shared uuid; every later scene holding it gets a fresh one.
+    """
+    if scene is None:
+        scene = bpy.context.scene
+    current = scene.get("uuid")
+    owner = next(
+        (other for other in bpy.data.scenes if other.get("uuid") == current), None
+    )
+    if current is None or (owner is not None and owner != scene):
+        scene["uuid"] = str(uuid.uuid4())
+    return scene["uuid"]
 
 
 def get_preferences_as_dict():
@@ -1920,10 +1935,25 @@ def is_upload_old(last_blend_upload: Optional[str]) -> int:
 
 
 def handle_nonblocking_request_task(task: client_tasks.Task):
+    if is_usage_report_task(task):
+        # background signal: never a popup, the console log is enough
+        if task.status == "error":
+            bk_logger.warning("Save-time usage report failed: %s", task.message)
+        elif task.status == "finished":
+            bk_logger.debug(
+                "Save-time usage report sent for scene %s",
+                task.data.get("json", {}).get("scene"),
+            )
+        return
     if task.status == "finished":
         reports.add_report(task.message)
     if task.status == "error":
         reports.add_report(task.message, type="ERROR")
+
+
+def is_usage_report_task(task: client_tasks.Task) -> bool:
+    """A non-blocking request task carrying the save-time usage report."""
+    return str(task.data.get("url", "")).endswith(client_lib.USAGE_REPORT_URL_SUFFIX)
 
 
 def string2list(text: str) -> list:

--- a/utils.py
+++ b/utils.py
@@ -30,6 +30,8 @@ import tempfile
 import uuid
 from typing import Optional, Union
 
+import requests
+
 import bpy
 from mathutils import Vector
 
@@ -763,6 +765,7 @@ def get_preferences_as_dict():
         "api_key_refresh": user_preferences.api_key_refresh,
         "api_key_timeout": user_preferences.api_key_timeout,
         "experimental_features": user_preferences.experimental_features,
+        "send_usage_data": user_preferences.send_usage_data,
         "keep_preferences": user_preferences.keep_preferences,
         # FILE PATHS
         "directory_behaviour": user_preferences.directory_behaviour,
@@ -825,6 +828,7 @@ def get_preferences() -> datas.Prefs:
         api_key_timeout=user_preferences.api_key_timeout,  # type: ignore[union-attr]
         experimental_features=user_preferences.experimental_features,  # type: ignore[union-attr]
         keep_preferences=user_preferences.keep_preferences,  # type: ignore[union-attr]
+        send_usage_data=user_preferences.send_usage_data,  # type: ignore[union-attr]
         # FILE PATHS
         directory_behaviour=user_preferences.directory_behaviour,  # type: ignore[union-attr]
         global_dir=user_preferences.global_dir,  # type: ignore[union-attr]
@@ -859,6 +863,22 @@ def get_preferences() -> datas.Prefs:
         material_import_automap=user_preferences.material_import_automap,  # type: ignore[union-attr]
     )
     return prefs
+
+
+def send_usage_data_updated(user_preferences, context):
+    """Push the usage-data choice to Blendkit-Client, then save the preferences.
+
+    Skipped while the preference is being set FROM the Client's settings
+    broadcast, which would otherwise echo the value straight back.
+    """
+    if not client_lib.applying_client_settings:
+        try:
+            client_lib.set_usage_data_opt_out(not user_preferences.send_usage_data)
+        except requests.RequestException as e:
+            bk_logger.warning(
+                "Could not store the usage-data choice in Blendkit-Client: %s", e
+            )
+    save_prefs(user_preferences, context)
 
 
 def save_prefs_without_save_userpref(user_preferences, context):

--- a/utils.py
+++ b/utils.py
@@ -1935,25 +1935,10 @@ def is_upload_old(last_blend_upload: Optional[str]) -> int:
 
 
 def handle_nonblocking_request_task(task: client_tasks.Task):
-    if is_usage_report_task(task):
-        # background signal: never a popup, the console log is enough
-        if task.status == "error":
-            bk_logger.warning("Save-time usage report failed: %s", task.message)
-        elif task.status == "finished":
-            bk_logger.debug(
-                "Save-time usage report sent for scene %s",
-                task.data.get("json", {}).get("scene"),
-            )
-        return
     if task.status == "finished":
         reports.add_report(task.message)
     if task.status == "error":
         reports.add_report(task.message, type="ERROR")
-
-
-def is_usage_report_task(task: client_tasks.Task) -> bool:
-    """A non-blocking request task carrying the save-time usage report."""
-    return str(task.data.get("url", "")).endswith(client_lib.USAGE_REPORT_URL_SUFFIX)
 
 
 def string2list(text: str) -> list:


### PR DESCRIPTION
## Why

The save-time usage report ("which Blendkit assets are still in the file") has been dead for years, twice over: `get_asset_usages()` returned `{}` on every call (#1013), and `client_lib.report_usages()` posted to a Client route (`/report_usages`) that only the retired Python daemon ever had; the Go Client answers 404 and `requests.post` does not raise, so nothing ever left the machine. Production holds 3 such reports for all of 2026.

The report is the first phase of the search-relevance and redistribution data plan (server side: BlenderKit-server #3727 storage, #3792 anonymous reports, #3805 per-scene locking). Nothing consumes it yet; the server keeps per-scene presence state (first download, first/last seen at a save, instance count, removed-at) for later simulation.

## What

- **`collect_present_assets(scene, file_wide)`** counts what a scene actually uses: objects and collection instances linked to it, materials per slot, its world, the scene itself when it is a scene asset; brushes and node groups are file-wide and attributed once, to the active scene. Orphan datablocks do not count (Blender drops them on save).
- **`build_save_reports()`** emits one report per scene that ever touched Blendkit, an empty list included (that is the removal signal). Unchanged presence is re-reported at most hourly (`SAVE_REPORT_HEARTBEAT_SECONDS`); any change reports on the next save. The memory is in-process, so the first save of every session reports.
- **Transport** through the Client's existing `/wrappers/nonblocking_request` to `/api/v1/usage_report/` (auth headers added by the Client). The result task is logged, never a popup; a Client that is not running is one warning and a normal save.
- **`utils.get_scene_id(scene=None)`** guarantees a uuid unique across the file. Blender copies custom properties when creating a scene from another ("New" included), so a second scene inherited the first one's uuid and the server merged their histories. First scene in `bpy.data.scenes` keeps it; later scenes get a fresh one. This also fixes download attribution in multi-scene files.

## Verified

- End to end on devel.blendkit.com with Blender 5.2 and Client 1.12.13: download, save, delete, save, save-as; a two-scene file (separate uuids and histories); logged out (anonymous scene rows); Client-down warning.
- 15 unit tests in `tests/test_save_presence.py`, run under a real `bpy` 5.0 wheel and in the Blender test matrix: collector counts, file-wide attribution, per-scene reports, uuid de-duplication, dedupe and heartbeat, transport call, silent result handling, background mode.

## Not changed

No UI, no prompt. `check_unused()` is untouched. The `proximitySet` field is sent empty for compatibility with the server serializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Second commit: the test runner skipped new test files

The Codecov report on the first push showed `tests/test_save_presence.py` at 0%: `tests/test.py` imported a hard-coded module list and the new file was not on it, so CI ran 513 tests, green, without the 15 new ones. The second commit keeps the list only for the modules that must run first (in that order) and appends every other `tests/test_*.py` automatically; a listed module that does not exist is fatal. CI now runs 528 tests; patch coverage 96% (the only misses are the runner script itself, which coverage cannot measure, plus one line in the test module).

Side finding while looking for the report: Codecov had processed nothing for this repo since the rename to `Blendkit` on 2026-08-21 (uploads were accepted and dropped). A GET on the Codecov v2 API with the new name resynced the repo; the workflows for this PR and for the latest `main` were rerun afterwards, so the base is current again.


## Third and fourth commits: review + endpoint

- `410c0cdb` (agajdosi's review): the usage-report result has its own `download.handle_usage_report_task`, routed from `timer.handle_task`; the generic non-blocking handler is generic again.
- `b478ccd8`: reports post to **`/api/v1/scene_save_reports/`** (Blendkit-server#3831 gives them their own endpoint instead of a `report_type` branch in the usage endpoint); `reportType` is gone from the payload. **Requires Blendkit-server#3831 on production before this is released.**


## Fifth commit: the Client's own route (agajdosi, round two)

The report no longer rides `wrappers/nonblocking_request` at all. The add-on posts `{"report": ...}` to the Client's dedicated **`/report_usages`** route, which forwards it to `/api/v1/scene_save_reports/` in the background and, like `/report_event`, creates no Task; the URL-sniffing handler and the timer routing are gone. **Depends on the bk_client route (branch `claude/usage-report-route`, PR to follow) being released in the v1.12 series.** A Client without it answers 404, which `scene_save` only logs.


## Sixth commit: renders

`render_complete` (once per render job) sends the same presence report for the rendered scene with `"event": "render"`; save reports carry `"event": "save"`. Renders are the strongest evidence of use and the only one for files that are rendered but never saved (test renders of HDRs and materials), and they cannot be reconstructed later. Deduplicated apart from saves. Server side: Blendkit-server#3835 (event column + render presence columns).


## Seventh commit: opt-out + the Client's own task type

- **"Send usage data to improve Blendkit"** preference (default on), per @Tweekazoid's point that machine-side data needs an opt-out shared by every host. The choice is stored in Blendkit-Client's shared settings (`usage_data_opt_out`, BlenderKit/bk_client#52) and enforced there; this add-on exposes it, pushes changes to `/settings/set`, mirrors the Client's settings broadcast back into the preference (a new `settings` task handler), and skips collecting entirely when off.
- Transport per @agajdosi: the report is a **`report_usages`** task of its own, routed by `timer.handle_task` like every other task type; nothing rides the generic wrapper any more.
- Performance, measured in Blender 5.2: 20,000 objects / 8,000 distinct assets collect in 100 ms (688 KB). Server cap raised to 10,000 with one-query asset resolution in Blendkit-server#3843.

**Release order:** bk_client#52 → Blendkit-server#3843 → this.
