### PR TITLE
fix: import unlock_options in ui_panels - panel Unlock button raised NameError [Better data collection]

### DIFF
--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -355,3 +355,13 @@ class TestDrawCommentResponseValidationCheckbox(unittest.TestCase):
         self.assertNotIn(
             ("prop", "new_comment_is_validation"), self.draw(0, is_validator=False)
         )
+
+
+class TestUnlockPanelDependencies(unittest.TestCase):
+    def test_unlock_options_is_importable_from_the_panel_module(self):
+        """#2245 used unlock_options in the locked-asset panel without importing it,
+        so drawing the Unlock button raised NameError in the released add-on."""
+        self.assertIs(
+            ui_panels.unlock_options, sys.modules[ui_panels.unlock_options.__name__]
+        )
+        self.assertTrue(callable(ui_panels.unlock_options.get_unlock_variant))

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -58,6 +58,7 @@ from . import (
     ratings_utils,
     search,
     ui,
+    unlock_options,
     upload,
     utils,
 )


### PR DESCRIPTION
## Production bug — the detail panel's Unlock button

#2245 made the locked-asset detail panel call `unlock_options.get_unlock_variant()` (`ui_panels.py:3807`) but never imported `unlock_options` into `ui_panels`. Drawing that branch raises `NameError`, so **the "Unlock" button is missing for every user who cannot download the asset** — the panel-side conversion path. Verified in the released tag `v3.21.2.260907` (in wide distribution since 2026-09-07 per telemetry).

The drag-and-drop upsell dialog is unaffected: `asset_bar/asset_drag_op.py` imports the module.

Nobody saw it because no test draws that panel branch and add-on draw errors don't reach Sentry. It surfaced through a test in #2301 that patches `ui_panels.unlock_options`.

## Fix

One import line, plus a test that pins the module attribute so the reference cannot silently dangle again.

Note for #2296/#2301: #2301 carries the same line; a trivial same-line conflict on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
